### PR TITLE
No need to convert string to string

### DIFF
--- a/src/Interact.jl
+++ b/src/Interact.jl
@@ -63,7 +63,7 @@ function register_widget(w::InputWidget)
     if haskey(widget_to_id, w)
         return widget_to_id[w]
     else
-        id = string(uuid4())
+        id = uuid4()
         widget_to_id[w] = id
         id_to_widget[id] = w
         return id


### PR DESCRIPTION
Since `uuid4()` returns a `string`, we do not need to convert its return value to a string again.