### PR TITLE
allow working with IJulia loaded from LOAD_PATH

### DIFF
--- a/src/Interact.jl
+++ b/src/Interact.jl
@@ -85,11 +85,11 @@ include("manipulate.jl")
 include("html_setup.jl")
 
 if isdefined(Main, :IJulia) && Main.IJulia.inited
-    if Pkg.installed("IJulia") >= v"0.1.3-"
-        include("IJulia/setup.jl")
-    else
+    ijuliaver = Pkg.installed("IJulia")
+    if ijuliaver === nothing || ijuliaver < v"0.1.3-"
         warn("Interact requires IJulia >= v0.1.3 to work properly.")
     end
+    include("IJulia/setup.jl")
 end
 
 end # module


### PR DESCRIPTION
`Pkg.installed` fails to detect IJulia provided through `LOAD_PATH`. And results in an exception when compared against the required version number.

This will prevent the exception and optimistically load `IJulia/setup.jl` (with a warning) when IJulia is detected but not its version.

It now loads `IJulia/setup.jl` even when it does find the IJulia version less than what is required, to keep the behavior uniform. But I'm not sure of the repercussions and am equally inclined to issue a different warning and disable it completely in this case.