### PR TITLE
Fix ambiguity warnings from Colors

### DIFF
--- a/src/Interact.jl
+++ b/src/Interact.jl
@@ -27,7 +27,7 @@ function statedict(w::Widget)
     msg
 end
 
-function parse{T}(msg, ::InputWidget{T})
+function parse{T}(::InputWidget{T}, msg)
     # Should return a value of type T, by default
     # msg itself is assumed to be the value.
     return convert(T, msg)
@@ -35,9 +35,9 @@ end
 
 # default cases
 
-parse{T <: Integer}(v, ::InputWidget{T}) = int(v)
-parse{T <: FloatingPoint}(v, ::InputWidget{T}) = float(v)
-parse(v, ::InputWidget{Bool}) = bool(v)
+parse{T <: Integer}(::InputWidget{T}, v) = int(v)
+parse{T <: FloatingPoint}(::InputWidget{T}, v) = float(v)
+parse(::InputWidget{Bool}, v) = bool(v)
 
 function update_view(w)
     # update the view of a widget.
@@ -46,7 +46,7 @@ end
 
 function recv{T}(widget ::InputWidget{T}, value)
     # Hand-off received value to the signal graph
-    parsed = parse(value, widget)
+    parsed = parse(widget, value)
     println(STDERR, signal(widget))
     push!(signal(widget), parsed)
     widget.value = parsed

--- a/src/Interact.jl
+++ b/src/Interact.jl
@@ -1,6 +1,6 @@
 module Interact
 
-using Reactive
+using Reactive, Compat
 
 import Base: mimewritable, writemime, parse, recv
 import Reactive.signal
@@ -35,9 +35,12 @@ end
 
 # default cases
 
-parse{T <: Integer}(::InputWidget{T}, v) = int(v)
-parse{T <: FloatingPoint}(::InputWidget{T}, v) = float(v)
-parse(::InputWidget{Bool}, v) = bool(v)
+parse{T <: Number}(::InputWidget{T}, v) = cnvt(T, v)
+
+cnvt(::Type{Bool}, v::AbstractString) = parse(Bool, v) # doesn't work, but needed for ambiguity resolution
+cnvt(::Type{Bool}, v) = v != 0
+cnvt{T}(::Type{T}, v::AbstractString) = parse(T, v)
+cnvt{T}(::Type{T}, v) = convert(T, v)
 
 function update_view(w)
     # update the view of a widget.

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -105,7 +105,7 @@ textbox(val; kwargs...) =
 textbox(val::String; kwargs...) =
     Textbox(value=utf8(val); kwargs...)
 
-function parse{T<:Number}(val, w::Textbox{T})
+function parse{T<:Number}(w::Textbox{T}, val)
     v = parse(T, val)
     if isa(w.range, Range)
         # force value to stay in range

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -143,6 +143,7 @@ end
 Base.getindex(x::OptionDict, y) = getindex(x.dict, y)
 Base.haskey(x::OptionDict, y) = haskey(x.dict, y)
 Base.keys(x::OptionDict) = x.keys
+Base.values(x::OptionDict) = [x.dict[k] for k in keys(x)]
 function Base.setindex!(x::OptionDict, v, k)
     if !haskey(x.dict, k)
         push!(x.keys, k)


### PR DESCRIPTION
This implements #74, extending Base.parse but in a way that avoids ambiguity warnings. Alternatively, we could use a different name for this.

Also a few other things in separate commits. GtkInteract.jl (an unregistered package) expects `values` to be implemented, so I thought I'd throw that in here (I can move it to GtkInteract if you prefer). The last commit is the one that makes me most nervous about the absence of tests, esp. since my IJulia is tuned to 0.4.
