### PR TITLE
Initialise JS in __init__ Function

### DIFF
--- a/src/IJulia/handle_msg.jl
+++ b/src/IJulia/handle_msg.jl
@@ -1,3 +1,4 @@
+import Interact.recv_msg
 
 function handle_msg(w::InputWidget, msg)
     if msg.content["data"]["method"] == "backbone"

--- a/src/IJulia/setup.jl
+++ b/src/IJulia/setup.jl
@@ -1,15 +1,12 @@
-
 using JSON
 using Reactive
-using Interact
 using Compat
 
-import Interact.update_view
-export mimewritable, writemime
+import Interact: HTML, Widget, InputWidget, Slider, Button, Textarea, Textbox, ToggleButton, Options, Checkbox, Latex, Progress
 
-const ijulia_js  = readall(joinpath(dirname(Base.source_path()), "ijulia.js"))
+const ijulia_js = readall(joinpath(dirname(@__FILE__), "ijulia.js"))
 
-try
+if displayable("text/html")
     display("text/html", """
      <div id="interact-js-shim">
          <script charset="utf-8">$(ijulia_js)</script>
@@ -23,7 +20,6 @@ try
             \$([IPython.events]).on("kernel_starting.Kernel kernel_restarting.Kernel", function () { window.interactLoadedFlag = false })
         </script>
      </div>""")
-catch
 end
 
 import IJulia

--- a/src/Interact.jl
+++ b/src/Interact.jl
@@ -31,10 +31,10 @@ parse_msg{T <: Number}(::InputWidget{T}, v::AbstractString) = parse(T, v)
 parse_msg(::InputWidget{Bool}, v::Number) = v != 0
 parse_msg{T}(::InputWidget{T}, v) = convert(T, v)
 
-function update_view(w)
-    # update the view of a widget.
-    # child packages need to override.
-end
+# function update_view(w)
+#     # update the view of a widget.
+#     # child packages need to override.
+# end
 
 function recv_msg{T}(widget ::InputWidget{T}, value)
     # Hand-off received value to the signal graph
@@ -76,8 +76,13 @@ include("compose.jl")
 include("manipulate.jl")
 include("html_setup.jl")
 
-if isdefined(Main, :IJulia) && Main.IJulia.inited
-    include("IJulia/setup.jl")
+const ijulia_setup_path = joinpath(dirname(Base.source_path()), "IJulia/setup.jl")
+
+function __init__()
+    init_widgets_js()
+    if isdefined(Main, :IJulia) && Main.IJulia.inited
+        include(ijulia_setup_path)
+    end
 end
 
 end # module

--- a/src/html_setup.jl
+++ b/src/html_setup.jl
@@ -4,9 +4,10 @@ using JSON
 
 const widgets_js = readall(joinpath(dirname(Base.source_path()), "widgets.js"))
 
-try
-    display("text/html", """<script charset="utf-8">$(widgets_js)</script>""")
-catch
+function init_widgets_js()
+    if displayable("text/html")
+        display("text/html", """<script charset="utf-8">$(widgets_js)</script>""")
+    end
 end
 
 function writemime(io, ::MIME{symbol("text/html")}, w::InputWidget)
@@ -27,4 +28,3 @@ function writemime(io, ::MIME{symbol("text/html")}, w::InputWidget)
           widgettype, "(\"", inputtype, "\",\"", id, "\",", JSON.json(statedict(w)), ")",
           ").elem);})(jQuery,InputWidgets)</script>")
 end
-


### PR DESCRIPTION
I think I was getting some problems with precompilation and js loading in IJulia (I was playing around with a module that had `using Interact` internally). I'm not 100% sure, but I think they were caused by the js not being loaded in an `__init__` function. Either way, afaict it seems sensible to load js in the `__init__` since it is affecting an external resource at runtime and not compile time, yeah? Or maybe I'm wrong and it's not needed as the js loading code is guaranteed to run at load time anyway after `using Interact` is called?

Anyway, even if it is a good idea, I'm still not 100% about this code being the best way to do it. I should note though that `Interact.__init__()` runs in `current_module() == Main` (or more accurately from whichever module `using Interact` is called from) hence the way I've had to import things. It seems to work in IJulia, but wasn't sure what other contexts it needs to be tested in.

Sorry if this is all a bit hand-wavy but I thought it better to send a possibly half-baked but working PR than just raise an issue.

Thanks for your work on this and all your other great packages.