### PR TITLE
remove conflicting HTML export with Base

### DIFF
--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -212,7 +212,7 @@ togglebuttons(opts; kwargs...) =
 
 ### Output Widgets
 
-export HTML, Latex, Progress
+export Latex, Progress
 
 
 type HTML <: Widget


### PR DESCRIPTION
This fixes the following warning whenever ``html()`` is first used,
```julia
julia> using Interact
htm
julia> html("foo")
WARNING: both Interact and Base export "HTML"; uses of it in module Main must be qualified
Interact.HTML("","foo")
```

I don't think there's a value in keeping the export since it hasn't been usable on Julia 0.4 anyway 