### PR TITLE
Fixed print syntax for Python3.

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,7 +3,7 @@ using Compat
 if isa(Pkg.installed("IJulia"), VersionNumber)
     using IJulia
     python = strip(readline(IJulia.jupyter), ['\n',' ', '#','!'])
-    ipywver = readstring(`$python -c 'import ipywidgets; print ipywidgets.__version__'`) |> strip |> VersionNumber
+    ipywver = readstring(`$python -c 'import ipywidgets; print(ipywidgets.__version__')`) |> strip |> VersionNumber
     info("ipywidgets version found: $ipywver")
     if ipywver < v"5.0.0"
         warn("""This version of Interact requires ipywidgets > 5.0 to work correctly.


### PR DESCRIPTION
Using an external Python3 interpreter instead of Py2 provided by Conda.jl, building `Interact.jl` fails with a syntax error due to `print` without parenthesis.

The `print()` syntax works for both Python 2 & 3.