### PR TITLE
Adds preserve to signal created by manipulate

### DIFF
--- a/src/manipulate.jl
+++ b/src/manipulate.jl
@@ -16,7 +16,7 @@ end
 function map_block(block, symbols)
     lambda = Expr(:(->), Expr(:tuple, symbols...),
                   block)
-    :(map($lambda, $(map(s->:(signal($s)), symbols)...), typ=Any))
+    :(preserve(map($lambda, $(map(s->:(signal($s)), symbols)...), typ=Any)))
 end
 
 function symbols(bindings)


### PR DESCRIPTION
Stops issues with manipulate signals being garbage collected when they go out of scope.
Fixes #115