### PR TITLE
Enables output created during signal updates to be displayed by Jupyter

### DIFF
--- a/src/IJulia/handle_msg.jl
+++ b/src/IJulia/handle_msg.jl
@@ -2,6 +2,7 @@ import Interact.recv_msg
 
 function handle_msg(w::InputWidget, msg)
     if msg.content["data"]["method"] == "backbone"
+        IJulia.set_cur_msg(msg)
         recv_msg(w, msg.content["data"]["sync_data"]["value"])
     end
 end
@@ -10,6 +11,7 @@ function handle_msg{T}(w::Button{T}, msg)
     try
         if msg.content["data"]["method"] == "custom" &&
             msg.content["data"]["content"]["event"] == "click"
+            IJulia.set_cur_msg(msg)
             # click event occured
             recv_msg(w, convert(T, w.value))
         end
@@ -20,6 +22,7 @@ end
 
 function handle_msg{view}(w::Options{view}, msg)
         if msg.content["data"]["method"] == "backbone"
+            IJulia.set_cur_msg(msg)
             key = string(msg.content["data"]["sync_data"]["value"])
             if haskey(w.options, key)
                 recv_msg(w, w.options[key])


### PR DESCRIPTION
It seems that the only reason Interact.jl can't display/print within `@manipulate`/`map` in IJulia (see #41), is just that IJulia is not sending the correct message header on stream messages and output/stream messages are being silently dropped by the front-end. This PR enables Interact to set the message header on stream messages.

Fixes (for the most part) #41
Requires a small change in IJulia, more details in the docstring of that PR: https://github.com/JuliaLang/IJulia.jl/pull/482