### PR TITLE
Enables correct display and updating of Signal{Widget}s

### DIFF
--- a/src/IJulia/setup.jl
+++ b/src/IJulia/setup.jl
@@ -4,8 +4,9 @@ using Compat
 import Compat.String
 
 import Base: writemime
-import Interact: update_view, Slider, Widget, InputWidget, Latex, HTML, recv_msg, statedict,
-                 Progress, Checkbox, Button, ToggleButton, Textarea, Textbox, Options
+import Interact: update_view, Slider, Widget, InputWidget, Latex, HTML,
+                 recv_msg, statedict, viewdict, Progress, Checkbox, Button,
+                 ToggleButton, Textarea, Textbox, Options
 
 export mimewritable, writemime
 
@@ -28,7 +29,7 @@ if displayable("text/html")
 end
 
 import IJulia
-import IJulia: metadata, display_dict
+import IJulia: metadata, mimewritable, limitstringmime
 using  IJulia.CommManager
 import IJulia.CommManager: register_comm
 import Base: show, mimewritable
@@ -74,6 +75,7 @@ function init_comm(x::Signal)
         function notify(value)
             mimes = keys(filter((k,v) -> v > 0, subscriptions))
             if length(mimes) > 0
+                #XXX @compat needed?
                 send_comm(comm, @compat Dict(:value =>
                                  get_data_dict(value, mimes)))
             end
@@ -88,23 +90,28 @@ end
 
 function metadata(x::Signal)
     comm = init_comm(x)
+    #XXX @compat needed?
     return @compat Dict("reactive"=>true,
                         "comm_id"=>comm.id)
 end
 
-function IJulia.display_dict(x::Signal)
-    IJulia.display_dict(value(x))
+for mime in IJulia.ipy_mime
+    @eval begin
+        function IJulia.mimewritable(m::MIME{Symbol($mime)}, s::Signal)
+            IJulia.mimewritable(m, value(s))
+        end
+
+        function IJulia.limitstringmime(m::MIME{Symbol($mime)}, s::Signal)
+            IJulia.limitstringmime(m, value(s))
+        end
+
+        function Base.show(io::IO, m::MIME{Symbol($mime)}, s::Signal)
+            Base.show(io, m, value(s))
+        end
+    end
 end
 
-# Render the value of a signal.
-mimewritable(m::MIME, s::Signal) =
-    mimewritable(m, s.value)
-
-# fixes ambiguity warnings
-@compat function Base.show(io::IO, m::MIME"text/plain", s::Signal)
-    Base.show(io, m, s.value)
-end
-
+#XXX @compat needed?
 @compat function Base.show(io::IO, m::MIME"text/csv", s::Signal)
     Base.show(io, m, s.value)
 end
@@ -113,22 +120,21 @@ end
     Base.show(io, m, s.value)
 end
 
-@compat function Base.show(io::IO, m::MIME, s::Signal)
-    Base.show(io, m, s.value)
-end
-
-@compat function Base.show(io::IO, ::MIME"text/html", w::InputWidget)
-    create_view(w)
-end
-
+widget_comms = Dict{Widget, Comm}()
 @compat function Base.show(io::IO, ::MIME"text/html", w::Widget)
-    create_view(w)
+    widget_comms[w] = create_view(w)
 end
 
-@compat function Base.show{T<:Widget}(io::IO, ::MIME"text/html", x::Signal{T})
+#Signals of widgets need to be handled specially
+function IJulia.limitstringmime{T<:Widget}(m::MIME"text/html", x::Signal{T})
     create_widget_signal(x)
+    ""
 end
 
+function metadata{T<:Widget}(x::Signal{T})
+    #avoid normal Signal updating, Signal{Widget} updates handled in create_widget_signal
+    return Dict()
+end
 
 ## This is for our own widgets.
 function register_comm(comm::Comm{:InputWidget}, msg)
@@ -136,7 +142,7 @@ function register_comm(comm::Comm{:InputWidget}, msg)
     comm.on_msg = (msg) -> recv_msg(w, msg.content["data"]["value"])
 end
 
-JSON.print(io::IO, s::Signal) = JSON.print(io, s.value)
+JSON.lower(s::Signal) = s.value
 
 ##################### IPython IPEP 23: Backbone.js Widgets #################
 
@@ -177,88 +183,76 @@ widget_class(w, suffix) = widget_class(w) * suffix
 view_name(w) = widget_class(w, "View")
 model_name(w) = widget_class(w, "Model")
 
-function metadata{T <: Widget}(x::Signal{T})
-    Dict()
-end
-
-function add_ipy3_state!(state)
-    for attr in ["color" "background" "width" "height" "border_color" "border_width" "border_style" "font_style" "font_weight" "font_size" "font_family" "padding" "margin" "border_radius"]
-        state[attr] = ""
-    end
-end
-
 function add_ipy4_state!(state)
-    state["_view_module"] = "jupyter-js-widgets"
-    state["_model_module"] = "jupyter-js-widgets"
+    state[:_view_module] = "jupyter-js-widgets"
+    state[:_model_module] = "jupyter-js-widgets"
 end
 
-const widget_comms = Dict{Widget, Comm}()
-function update_view(w; src=w)
-    send_comm(widget_comms[w], view_state(w, src=src))
-end
-
-function view_state(w::InputWidget; src::InputWidget=w)
-    msg = Dict()
-    msg["method"] = "update"
+function view_state(w::Widget)
+    msg = viewdict(w)
+    msg[:method] = "update"
+    msg[:_view_name] = view_name(w)
     state = Dict()
-    state["msg_throttle"] = 3
-    state["_view_name"] = view_name(src)
-    state["_model_name"] = model_name(src)
-    state["model_name"] =  model_name(src)
-    state["description"] = w.label
-    state["visible"] = true
-    state["disabled"] = false
-    state["readout"] = true
-    add_ipy3_state!(state)
+    state[:msg_throttle] = 3
+    state[:_model_name] = model_name(w)
+    state[:model_name] = model_name(w)
+    state[:description] = :label in fieldnames(w) ? w.label : ""
     add_ipy4_state!(state)
-    msg["state"] = merge(state, statedict(src))
+    msg[:state] = merge(state, statedict(w))
+    # @show string(w) model_name(w) view_name(w) typeof(w)
     msg
 end
 
-function view_state(w::Widget; src::Widget=w)
-    msg = Dict()
-    msg["method"] = "update"
-    state = Dict()
-    state["msg_throttle"] = 3
-    state["_view_name"] = view_name(src)
-    state["_model_name"] = model_name(src)
-    state["model_name"] = model_name(src)
-    state["description"] = w.label
-    state["visible"] = true
-    state["disabled"] = false
-    add_ipy3_state!(state)
-    add_ipy4_state!(state)
-
-    msg["state"] = merge(state, statedict(src))
-    msg
+function new_widget_dict(w::Widget)
+    # wdata = view_state(w) #XXX check if can delete
+    wdata = Dict(:_view_name => view_name(w))
+    add_ipy4_state!(wdata)
+    wdata[:_model_name] = model_name(w)
+    wdata[:model_name] = model_name(w)
+    wdata
 end
 
 function create_view(w::Widget)
+    #create the widget on the front-end by opening the comm
     if haskey(widget_comms, w)
+        #existing (non Signal{Widget}.value) widgets
         comm = widget_comms[w]
     else
-        comm = Comm("jupyter.widget", data=merge(Dict{AbstractString, Any}([
-            ("model_name", model_name(w)),
-            ("_model_name", model_name(w)), # Jupyter 4.0 missing (https://github.com/ipython/ipywidgets/pull/84)
-            ("_view_module", "jupyter-js-widgets"),
-            ("_model_module", "jupyter-js-widgets"),
-        ]), view_state(w)))
-        widget_comms[w] = comm
-        # Send a full state update message.
-        update_view(w) # This is redundant on 4.0 but keeps it working on Jupyter 3.0
-
-        # dispatch messages to widget's handler
-        comm.on_msg = msg -> handle_msg(w, msg)
-        nothing # display() nothing
+        #new Widgets
+        comm = Comm("jupyter.widget", data=new_widget_dict(w))
     end
-
-    send_comm(comm, @compat Dict("method"=>"display"))
+    # dispatch messages to widget's handler
+    comm.on_msg = msg -> handle_msg(w, msg)
+    send_comm(comm, view_state(w)) #set the state of newly created widget
+    send_comm(comm, Dict(:method=>"display"))
+    comm
 end
 
-function create_widget_signal(s)
-    create_view(s.value)
-    local target = s.value
-    preserve(map(x->update_view(target, src=x), s, init=nothing))
+function update_view(w, comm::Comm=widget_comms[w]; prevw=w)
+    if typeof(w) != typeof(prevw)
+        #If the widget has changed type a new widget must be set up and the old
+        #one removed.
+        remove_view(comm, prevw)
+        comm = create_view(w)
+    else
+        send_comm(comm, view_state(w))
+    end
+    comm
+end
+
+function remove_view(comm::Comm, prevw::Widget)
+    #closing the comm removes the widget(s) associated with that comm
+    close_comm(comm)
+end
+
+function create_widget_signal(s::Signal{Widget})
+    local prev_widg = s.value
+    local comm = create_view(s.value)
+    map(s, init=nothing) do x
+        comm = update_view(x, comm; prevw=prev_widg)
+        prev_widg = x
+        nothing
+    end |> preserve
 end
 
 include("statedict.jl")

--- a/src/IJulia/statedict.jl
+++ b/src/IJulia/statedict.jl
@@ -1,3 +1,7 @@
+function viewdict(w::Widget)
+    Dict()
+end
+
 @compat Interact.statedict(s::Union{Slider, Progress}) =
     @compat Dict(:value=>s.value,
          :min=>first(s.range),

--- a/src/Interact.jl
+++ b/src/Interact.jl
@@ -26,6 +26,10 @@ function statedict(w)
     msg
 end
 
+function viewdict(w)
+    Dict()
+end
+
 # Convert e.g. JSON values into Julia values
 parse_msg{T <: Number}(::InputWidget{T}, v::AbstractString) = parse(T, v)
 parse_msg(::InputWidget{Bool}, v::Number) = v != 0
@@ -37,7 +41,6 @@ child packages need to override this function
 """
 function update_view end
 
-
 function error_handler(sig, value, err)
     Reactive.print_error(sig, value, err, open("/tmp/Interact.log", "a"))
 end
@@ -45,10 +48,11 @@ end
 function recv_msg{T}(widget ::InputWidget{T}, value)
     # Hand-off received value to the signal graph
     parsed = parse_msg(widget, value)
-    #println(STDERR, signal(widget))
+    # println(STDERR, "sig = $(signal(widget))", ", value = $value", ", parsed = $parsed")
     push!(signal(widget), parsed)
     widget.value = parsed
     if value != parsed
+        #XXX when would this happen?
         update_view(widget)
     end
 end


### PR DESCRIPTION
Requires this minor patch to IJulia: JuliaLang/IJulia.jl#487

changes:
1) Instead of Interact overloading `IJulia.display_dict(s::Signal)` as `IJulia.display_dict(s.value)`, Interact now overloads `IJulia.mimewriteable(m::MIME, s::Signal)` and `IJulia.limitstringmime(m, s)`, this allows us better control over Signal{Widget} display.

2) When the value of a `Signal{Widget}` changes, the comm of the original widget is closed (which removes all widgets associated with that comm from the front-end) and `create_view` is called for the new value, creating a new comm and displaying the new widget. 

N.b. this means that if a widget is displayed as the value of a `Signal{Widget}` and also displayed somewhere else in the notebook, when the `Signal{Widget}` updates, the widget will disappear from all locations in the notebook, not just the `Signal{Widget}` display. I know a way to fix this if it's desired (was mostly there in the first commit of this), but I think there might be some downsides, loss of simplicity being one.

3) JSON.print changed to JSON.lower - fixes a stack overflow error that occurs (I think) when converting Signal{Widget}s to json.

4) minor code cleanups

Dev docs, and a few more PRs (vertical sliders, SelectionSliders, possibly some other fixes) to follow in the next few days all being well.

Fixes #126 #47 