### PR TITLE
Various widget updates

### DIFF
--- a/src/IJulia/handle_msg.jl
+++ b/src/IJulia/handle_msg.jl
@@ -23,9 +23,16 @@ end
 function handle_msg{view}(w::Options{view}, msg)
         if msg.content["data"]["method"] == "backbone"
             IJulia.set_cur_msg(msg)
-            key = string(msg.content["data"]["sync_data"]["value"])
-            if haskey(w.options, key)
-                recv_msg(w, w.options[key])
+            if view == :SelectMultiple
+                keys = msg.content["data"]["sync_data"]["value"]
+                if map(key->haskey(w.options, key), keys) |> all
+                    recv_msg(w, map(key->w.options[key], keys))
+                end
+            else
+                key = string(msg.content["data"]["sync_data"]["value"])
+                if haskey(w.options, key)
+                    recv_msg(w, w.options[key])
+                end
             end
         end
 end

--- a/src/IJulia/statedict.jl
+++ b/src/IJulia/statedict.jl
@@ -1,3 +1,10 @@
+Interact.viewdict(s::Union{Slider, Progress}) =
+    Dict{Symbol, Any}(:orientation => s.orientation)
+
+Interact.viewdict(d::Options) =
+    Dict{Symbol, Any}(:tooltips => d.tooltips,
+                    :orientation => d.orientation)
+
 @compat Interact.statedict(s::Union{Slider, Progress}) =
     @compat Dict(:value=>s.value,
          :min=>first(s.range),
@@ -5,6 +12,7 @@
          :max=>last(s.range),
          :model_name => "FloatSliderModel",
          :_model_name => "FloatSliderModel",
+         :readout => s.readout,
          :readout_format => s.readout_format,
          :continuous_update=>s.continuous_update,
      )
@@ -15,6 +23,7 @@ Interact.statedict(d::Options) =
          :value => d.value_label,
          :icons=>d.icons,
          :tooltips=>d.tooltips,
+         :readout => d.readout,
          :_options_labels=>collect(keys(d.options)))
 
 function statedict(w::Widget)

--- a/src/Interact.jl
+++ b/src/Interact.jl
@@ -26,6 +26,10 @@ function statedict(w)
     msg
 end
 
+function viewdict(w::Widget)
+    Dict()
+end
+
 # Convert e.g. JSON values into Julia values
 parse_msg{T <: Number}(::InputWidget{T}, v::AbstractString) = parse(T, v)
 parse_msg(::InputWidget{Bool}, v::Number) = v != 0

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -1,7 +1,7 @@
 import Base: convert, haskey, setindex!, getindex
 export slider, togglebutton, button,
        checkbox, textbox, textarea,
-       radiobuttons, dropdown, select,
+       radiobuttons, dropdown, selectone, selectmulti,
        togglebuttons, html, latex,
        progress, widget, selection_slider
 
@@ -275,8 +275,18 @@ radiobuttons: see the help for `dropdown`
 radiobuttons(opts; kwargs...) =
     Options(:RadioButtons, opts; kwargs...)
 
-select(opts; kwargs...) =
+"""
+selectone: see the help for `dropdown`
+"""
+selectone(opts; kwargs...) =
     Options(:Select, opts; kwargs...)
+
+"""
+selectmulti: see the help for `dropdown`
+"""
+selectmulti(opts; signal=Signal(collect(opts)[1:1]), kwargs...) = begin
+    Options(:SelectMultiple, opts; signal=signal, kwargs...)
+end
 
 """
 togglebuttons: see the help for `dropdown`

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -16,6 +16,8 @@ type Slider{T<:Number} <: InputWidget{T}
     label::AbstractString
     value::T
     range::Range{T}
+    orientation::String
+    readout::Bool
     readout_format::AbstractString
     continuous_update::Bool
 end
@@ -25,7 +27,7 @@ medianelement(r::Range) = r[(1+length(r))>>1]
 
 slider(args...) = Slider(args...)
 """
-    slider(range; value, signal, label="", continuous_update=true)
+    slider(range; value, signal, label="", readout=true, continuous_update=true)
 
 Create a slider widget with the specified `range`. Optionally specify
 the starting `value` (defaults to the median of `range`), provide the
@@ -36,9 +38,11 @@ slider{T}(range::Range{T};
           value=medianelement(range),
           signal::Signal{T}=Signal(value),
           label="",
+          orientation="horizontal",
+          readout=true,
           readout_format=T <: Integer ? "d" : ".3f",
           continuous_update=true) =
-              Slider(signal, label, value, range, readout_format, continuous_update)
+              Slider(signal, label, value, range, orientation, readout, readout_format, continuous_update)
 
 ######################### Checkbox ###########################
 
@@ -213,6 +217,8 @@ type Options{view, T} <: InputWidget{T}
     options::OptionDict
     icons::AbstractArray
     tooltips::AbstractArray
+    readout::Bool
+    orientation::AbstractString
 end
 
 Options(view::Symbol, options::OptionDict;
@@ -222,9 +228,11 @@ Options(view::Symbol, options::OptionDict;
         icons=[],
         tooltips=[],
         typ=valtype(options.dict),
-        signal=Signal(valtype(options.dict), value)) =
+        signal=Signal(valtype(options.dict), value),
+        readout=true,
+        orientation="horizontal") =
     Options{view, typ}(signal, label, value, value_label,
-                       options, icons, tooltips)
+                       options, icons, tooltips, readout, orientation)
 
 addoption(opts, v::NTuple{2}) = opts[string(v[1])] = v[2]
 addoption(opts, v) = opts[string(v)] = v
@@ -322,11 +330,16 @@ type Progress <: Widget
     label::AbstractString
     value::Int
     range::Range
+    orientation::String
+    readout::Bool
+    readout_format::String
+    continuous_update::Bool
 end
 
 progress(args...) = Progress(args...)
-progress(;label="", value=0, range=0:100) =
-    Progress(label, value, range)
+progress(;label="", value=0, range=0:100, orientation="horizontal",
+            readout=true, readout_format="d", continuous_update=true) =
+    Progress(label, value, range, orientation, readout, readout_format, continuous_update)
 
 # Make a widget out of a domain
 widget(x::Signal, label="") = x

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -3,7 +3,7 @@ export slider, togglebutton, button,
        checkbox, textbox, textarea,
        radiobuttons, dropdown, select,
        togglebuttons, html, latex,
-       progress, widget
+       progress, widget, selection_slider
 
 const Empty = VERSION < v"0.4.0-dev" ? Nothing : Void
 
@@ -283,6 +283,12 @@ togglebuttons: see the help for `dropdown`
 """
 togglebuttons(opts; kwargs...) =
     Options(:ToggleButtons, opts; kwargs...)
+
+"""
+selection_slider: see the help for `dropdown`
+"""
+selection_slider(opts; kwargs...) =
+    Options(:SelectionSlider, opts; kwargs...)
 
 ### Output Widgets
 


### PR DESCRIPTION
1. Adds SelectionSlider widget (`selection_slider`)
1. Adds SelectMultiple widget (`selectmulti`)
1. Renames `select` to `selectone` (to avoid name conflict with Base.select)
1. Enables vertical sliders (`orientation = "vertical"`)
1. Makes readout optional on sliders (`readout=false`)

More info in the commit messages. 

N.b. Each commit is in its own branch that branches off the commit before. The first commit shown below is the Signal{Widget} one from #131
